### PR TITLE
chore: update job name for image build task

### DIFF
--- a/.github/workflows/dockerhub-latest-image.yml
+++ b/.github/workflows/dockerhub-latest-image.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build:
-    name: Build and push web image
+    name: Build and push image
     if: ${{ github.repository == 'warjiang/kube-consul-register' }}
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/dockerhub-released-image.yml
+++ b/.github/workflows/dockerhub-released-image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    name: Build and push web image
+    name: Build and push image
     if: ${{ github.repository == 'warjiang/kube-consul-register' }}
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Summary by Sourcery

Rename job names in GitHub Actions workflows to use "Build and push image" instead of "Build and push web image"

CI:
- Update job name in dockerhub-latest-image.yml
- Update job name in dockerhub-released-image.yml